### PR TITLE
Update slang-vs-extension for library rename and versioning

### DIFF
--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -32,7 +32,8 @@ jobs:
         $verName="${{steps.download-win32.outputs.version}}";
         $verName=$verName.SubString(1, ($verName.Length-1));
         Expand-Archive -Path slang-$verName-windows-x86_64.zip -DestinationPath .\SlangServer
-        Copy-Item -Path .\SlangServer\bin\slang.dll .\SlangServer\slang.dll
+        Copy-Item -Path .\SlangServer\bin\slang.dll .\SlangServer\slang.dll -ErrorAction SilentlyContinue
+        Copy-Item -Path .\SlangServer\bin\slang-compiler.dll .\SlangServer\slang-compiler.dll -ErrorAction SilentlyContinue
         Copy-Item -Path .\SlangServer\bin\slangd.exe .\SlangServer\slangd.exe
         MSBuild.exe SlangClient.sln -property:Configuration=Release -property:Platform="Any CPU"
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -34,6 +34,7 @@ jobs:
         Expand-Archive -Path slang-$verName-windows-x86_64.zip -DestinationPath .\SlangServer
         Copy-Item -Path .\SlangServer\bin\slang.dll .\SlangServer\slang.dll -ErrorAction SilentlyContinue
         Copy-Item -Path .\SlangServer\bin\slang-compiler.dll .\SlangServer\slang-compiler.dll -ErrorAction SilentlyContinue
+        Copy-Item -Path .\SlangServer\bin\slang-glsl-module.dll .\SlangServer\slang-glsl-module.dll
         Copy-Item -Path .\SlangServer\bin\slangd.exe .\SlangServer\slangd.exe
         MSBuild.exe SlangClient.sln -property:Configuration=Release -property:Platform="Any CPU"
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,8 @@ jobs:
         $verName="${{steps.download-win32.outputs.version}}";
         $verName=$verName.SubString(1, ($verName.Length-1));
         Expand-Archive -Path slang-$verName-windows-x86_64.zip -DestinationPath .\SlangServer
-        Copy-Item -Path .\SlangServer\bin\slang.dll .\SlangServer\slang.dll
+        Copy-Item -Path .\SlangServer\bin\slang.dll .\SlangServer\slang.dll -ErrorAction SilentlyContinue
+        Copy-Item -Path .\SlangServer\bin\slang-compiler.dll .\SlangServer\slang-compiler.dll -ErrorAction SilentlyContinue
         Copy-Item -Path .\SlangServer\bin\slangd.exe .\SlangServer\slangd.exe
         MSBuild.exe SlangClient.sln -property:Configuration=Release -property:Platform="Any CPU"
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,7 @@ jobs:
         Expand-Archive -Path slang-$verName-windows-x86_64.zip -DestinationPath .\SlangServer
         Copy-Item -Path .\SlangServer\bin\slang.dll .\SlangServer\slang.dll -ErrorAction SilentlyContinue
         Copy-Item -Path .\SlangServer\bin\slang-compiler.dll .\SlangServer\slang-compiler.dll -ErrorAction SilentlyContinue
+        Copy-Item -Path .\SlangServer\bin\slang-glsl-module.dll .\SlangServer\slang-glsl-module.dll
         Copy-Item -Path .\SlangServer\bin\slangd.exe .\SlangServer\slangd.exe
         MSBuild.exe SlangClient.sln -property:Configuration=Release -property:Platform="Any CPU"
     - uses: actions/upload-artifact@v4

--- a/SlangClient.csproj
+++ b/SlangClient.csproj
@@ -88,6 +88,11 @@
       <IncludeInVSIX>true</IncludeInVSIX>
       <VSIXSubPath>SlangServer</VSIXSubPath>
     </Content>
+    <Content Include="SlangServer\slang-glsl-module.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <VSIXSubPath>SlangServer</VSIXSubPath>
+    </Content>
     <Content Include="SlangServer\slangd.exe">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>

--- a/SlangClient.csproj
+++ b/SlangClient.csproj
@@ -78,7 +78,12 @@
     </Content>
     <Content Include="Resources\slangicon.png" />
     <Content Include="Resources\slangicon_small.png" />
-    <Content Include="SlangServer\slang.dll">
+    <Content Include="SlangServer\slang.dll" Condition="Exists('SlangServer\slang.dll')">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <VSIXSubPath>SlangServer</VSIXSubPath>
+    </Content>
+    <Content Include="SlangServer\slang-compiler.dll" Condition="Exists('SlangServer\slang-compiler.dll')">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
       <VSIXSubPath>SlangServer</VSIXSubPath>


### PR DESCRIPTION
For shader-slang/slang#8828

Handle new filename patterns introduced by shader-slang/slang#4016

Include `slang-glsl-module.dll` in vsix package